### PR TITLE
Productionisation ofJSON Schema script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.8",
-        "phpstan/phpdoc-parser": "^1.33"
+        "phpstan/phpdoc-parser": "^1.33",
+        "opis/json-schema": "^2.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.59",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e1de9afccdf23bb44b5d1e4b3d37f75",
+    "content-hash": "6f7422b6d3402672ae20118117fecc9b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -330,6 +330,196 @@
                 }
             ],
             "time": "2024-07-18T11:15:46+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/c48df6d7089a45f01e1c82432348f2d5976f9bfb",
+                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.0",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.3.0"
+            },
+            "time": "2022-01-08T20:38:03+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
+                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.0.1"
+            },
+            "time": "2022-01-14T15:42:23+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/src/Schema/CompartmentSchema.php
+++ b/src/Schema/CompartmentSchema.php
@@ -88,7 +88,7 @@ class CompartmentSchema
         }
 
         $this->number = $number;
-        $this->boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::POLYGON);
-        $this->centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::POINT);
+        $this->boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::Polygon);
+        $this->centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::Point);
     }
 }

--- a/src/Schema/Enum/GeojsonGeometryTypeEnum.php
+++ b/src/Schema/Enum/GeojsonGeometryTypeEnum.php
@@ -7,6 +7,6 @@ namespace CloudForest\ApiClientPhp\Schema\Enum;
 enum GeojsonGeometryTypeEnum: string
 {
     // Lower case values to match GeoJSON spec
-    case POLYGON = 'Polygon';
-    case POINT = 'Point';
+    case Polygon = 'Polygon';
+    case Point = 'Point';
 }

--- a/src/Schema/Enum/GeojsonTypeEnum.php
+++ b/src/Schema/Enum/GeojsonTypeEnum.php
@@ -7,5 +7,5 @@ namespace CloudForest\ApiClientPhp\Schema\Enum;
 enum GeojsonTypeEnum: string
 {
     // Lower case value to match GeoJSON spec
-    case FEATURE = 'Feature';
+    case Feature = 'Feature';
 }

--- a/src/Schema/GeojsonSchema.php
+++ b/src/Schema/GeojsonSchema.php
@@ -22,7 +22,7 @@ class GeojsonSchema
      *
      * @var GeojsonTypeEnum
      */
-    public $type = GeojsonTypeEnum::FEATURE;
+    public $type = GeojsonTypeEnum::Feature;
 
     /**
      * The Geojson geometry.

--- a/src/Schema/SubcompartmentSchema.php
+++ b/src/Schema/SubcompartmentSchema.php
@@ -99,7 +99,7 @@ class SubcompartmentSchema
         }
 
         $this->letter = $letter;
-        $this->boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::POLYGON);
-        $this->centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::POINT);
+        $this->boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::Polygon);
+        $this->centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::Point);
     }
 }

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -160,7 +160,10 @@ class JsonSchema
         $generic = $type->genericTypes[0];
 
         if ($generic instanceof ArrayShapeNode) {
-            $schema = $this->handleType($generic);
+            $schema = [
+                'type' => 'array',
+                'items' => $this->handleType($generic)
+            ];
         } elseif ($generic instanceof IdentifierTypeNode) {
             if (class_exists($this->namespace . $generic->name)) {
                 $schema = [

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -22,10 +22,10 @@ use ReflectionEnum;
  * Print out a JSON Schema of the Inventory specification, starting at the top
  * with the CompartmentSchema class.
  *
- * It by no means supports all PHPDoc type annotations, but hopefully it
- * will always throw an exception in these cases rather than coming up with an
- * incorrect JSON schema. We can then work out whether to change the PHPDoc or
- * upgrade this to support it.
+ * This does not support all PHPDoc var tag types, but it is intended to throw
+ * an exception for those it cannot support, rather than coming up with an
+ * incorrect JSON schema. When an exception is encountered, we can then work out
+ * whether to change the PHPDoc or upgrade this code to support it.
  *
  * It uses PHPStan's PHPDoc parser, so it therefore supports phpstan's take on
  * PHPDoc types: https://phpstan.org/writing-php-code/phpdoc-types
@@ -39,8 +39,8 @@ class JsonSchema
     private Lexer $lexer;
 
     /**
-     * Set up the doc block parser to extract var tags. It can be then be reused
-     * throughout the recursive calls to $this->generate.
+     * Set up the doc block parser to extract var tags in the constructor. It
+     * can be then be reused throughout the recursive calls to $this->generate.
      * @return void
      */
     public function __construct()
@@ -52,7 +52,7 @@ class JsonSchema
     }
 
     /**
-     * Static method to run the generator.
+     * Static method to run the generator from composer.json.
      * @see composer.json
      * @return void
      * @throws \Exception
@@ -67,9 +67,9 @@ class JsonSchema
     /**
      * Generate a JsonSchema for the class specified in $className.
      *
-     * Use reflection to get a list of the class properties.
+     * First, use reflection to get a list of the class properties.
      *
-     * Then loop through the properties to add them to the schema. For each
+     * Then, loop through the properties to add them to the schema. For each
      * property, get the doc block and extract the var tags. Ensure there
      * is only one: it only makes sense to map one var tag to a JSON Schema
      * property. Then work out what type is in the var tag and handle it
@@ -93,7 +93,6 @@ class JsonSchema
         }
         $reflector = new ReflectionClass($className);
         $properties = $reflector->getProperties();
-
 
         foreach ($properties as $property) {
             $propertyName = $property->getName();
@@ -130,13 +129,13 @@ class JsonSchema
      *
      * Limitation 2: The GenericTypeNode has two members, type and genericTypes,
      * which allows it to support multiple generics like SomethingClever<T1, T2>
-     * Currently we only support a single generic.
+     * However, currently we only support a single generic: SmethingSimple<T1>
      *
      * EG1: An array with an array shape generic, used for coordinates:
      * array<array{float,float}>
      *
      * EG2: A list of children from our schema:
-     * [Array<Subcompartment>
+     * Array<Subcompartment>
      *
      * EG3: A list of a built-in type:
      * Array<string>

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -162,7 +162,7 @@ class JsonSchema
         if ($generic instanceof ArrayShapeNode) {
             $schema = [
                 'type' => 'array',
-                'items' => $this->handleType($generic)
+                'items' => $this->handleType($generic),
             ];
         } elseif ($generic instanceof IdentifierTypeNode) {
             if (class_exists($this->namespace . $generic->name)) {

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -147,7 +147,7 @@ class JsonSchema
             if ($generic instanceof ArrayShapeNode) {
                 $schema = $this->handleType($generic);
             } elseif ($generic instanceof IdentifierTypeNode) {
-                // EG2: A list of children fro our schema
+                // EG2: A list of children from our schema
                 if (class_exists($this->namespace . $generic->name)) {
                     $schema = [
                         'type' => 'array',

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -139,32 +139,35 @@ class JsonSchema
         $schema = [];
         $typeName = $type->type->name;
         // Limitation 1: Only support array types with generics
-        if ($typeName === 'array') {
-            // Limitation2: Only support a single generic.
-            $generic = $type->genericTypes[0];
+        if ($typeName !== 'array') {
+            throw new \Exception('Cannot handle that type yet: ' . $typeName);
+        }
 
-            // EG1: Array shape generics
-            if ($generic instanceof ArrayShapeNode) {
-                $schema = $this->handleType($generic);
-            } elseif ($generic instanceof IdentifierTypeNode) {
-                // EG2: A list of children from our schema
-                if (class_exists($this->namespace . $generic->name)) {
-                    $schema = [
-                        'type' => 'array',
-                        'items' => $this->generate($generic->name),
-                    ];
-                }
+        // Limitation2: Only support a single generic.
+        if (count($type->genericTypes) > 1) {
+            throw new \Exception('Cannot handle more than one generic' . $typeName);
+        }
+        $generic = $type->genericTypes[0];
 
-                // EG3: A list of built-ins
-                else {
-                    $schema = [
-                        'type' => 'array',
-                        'items' => $this->handleType($generic),
-                    ];
-                }
+        // EG1: Array shape generics
+        if ($generic instanceof ArrayShapeNode) {
+            $schema = $this->handleType($generic);
+        } elseif ($generic instanceof IdentifierTypeNode) {
+            // EG2: A list of children from our schema
+            if (class_exists($this->namespace . $generic->name)) {
+                $schema = [
+                    'type' => 'array',
+                    'items' => $this->generate($generic->name),
+                ];
             }
-        } else {
-            throw new \Exception('Cannot handle that type yet: ' . $type->type->name);
+
+            // EG3: A list of built-ins
+            else {
+                $schema = [
+                    'type' => 'array',
+                    'items' => $this->handleType($generic),
+                ];
+            }
         }
         return $schema;
     }

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -253,7 +253,7 @@ class JsonSchema
             $enumName = $this->namespace . 'Enum\\' . $type->name;
             $refEnum = new ReflectionEnum($enumName);
             foreach ($refEnum->getCases() as $case) {
-                $t['enum'][] = $case->name;
+                $schema['enum'][] = $case->name;
             }
         } else {
             $schema = ['type' => $this->castType($type->name)];

--- a/src/Scripts/JsonSchema.php
+++ b/src/Scripts/JsonSchema.php
@@ -26,6 +26,21 @@ use ReflectionEnum;
 class JsonSchema
 {
     private string $namespace = 'CloudForest\\ApiClientPhp\\Schema\\';
+    private PhpDocParser $phpDocParser;
+    private Lexer $lexer;
+
+    /**
+     * Set up the doc block parser to extract @var tags just once. It can be
+     * used throughout the recursive calls to £this->generate.
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->lexer = new Lexer(false);
+        $constExprParser = new ConstExprParser();
+        $typeParser = new TypeParser($constExprParser);
+        $this->phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+    }
 
     /**
      * Static method to run the generator.
@@ -62,87 +77,111 @@ class JsonSchema
         $reflector = new ReflectionClass($className);
         $properties = $reflector->getProperties();
 
-        // Set up doc block parser to extract @var tags
-        $lexer = new Lexer(false);
-        $constExprParser = new ConstExprParser();
-        $typeParser = new TypeParser($constExprParser);
-        $phpDocParser = new PhpDocParser($typeParser, $constExprParser);
-
-        // Loop through the properties and add them to the schema.
+        // Loop through the properties to add them to the schema. For each
+        // property, get the doc block and extract the @var tags. Ensure there
+        // is only one: it only makes sense to map one var tag to a JSON Schema
+        // property. Then work out what type is in the £var tag and handle it
+        // accordingly.
         foreach ($properties as $property) {
             $propertyName = $property->getName();
 
-            // Get the @var from the doc block for the property
             $docBlock = $property->getDocComment();
             if (!$docBlock) {
                 throw new \Exception('Failed to find doc block for ' . $propertyName);
             }
-            $tokens = new TokenIterator($lexer->tokenize($docBlock));
-            $phpDocNode = $phpDocParser->parse($tokens);
+            $tokens = new TokenIterator($this->lexer->tokenize($docBlock));
+            $phpDocNode = $this->phpDocParser->parse($tokens);
             $vars = $phpDocNode->getVarTagValues();
 
-            // Make sure there's only one. It only makes sense to map one @var to
-            // a JSON Schema property.
             if (count($vars) > 1) {
                 throw new \Exception('Only one @var per property is supported');
             }
             $var = $vars[0];
 
-            // Split up a type using generics and handle it. We only handle
-            // array generics at the moment, ie array<T>
-            //
-            // EG1: An array with an array shape generic, used for coordinates:
-            // array<array{float,float}>
-            // EG2: A list of children:
-            // @var Array<Subcompartment>
-            // EG3: An array of a built-in type
-            // @var Array<string>
             if ($var->type instanceof GenericTypeNode) {
-                $typeName = $var->type->type->name;
-                if ($typeName === 'array') {
-                    $generic = $var->type->genericTypes[0];
-
-                    // Array shape generics
-                    if ($generic instanceof ArrayShapeNode) {
-                        $schema['properties'][$propertyName] = $this->handleType($generic);
-                    }
-
-                    // A list of children
-                    elseif ($generic instanceof IdentifierTypeNode) {
-                        if (class_exists($this->namespace . $generic->name)) {
-                            $schema['properties'][$propertyName] = [
-                                'type' => 'array',
-                                'items' => $this->generate($generic->name),
-                            ];
-                        }
-
-                        // A list of built-ins
-                        else {
-                            $schema['properties'][$propertyName] = [
-                                'type' => 'array',
-                                'items' => $this->handleType($generic),
-                            ];
-                        }
-                    }
-                }
-            }
-
-            // Split up a compound type and handle each one seperately. For example:
-            // @var string|null
-            elseif ($var->type instanceof UnionTypeNode) {
-                $schema['properties'][$propertyName] = ['anyOf' => []];
-                foreach ($var->type->types as $type) {
-                    $schema['properties'][$propertyName]['anyOf'][] = $this->handleType($type);
-                }
-            }
-
-            // Handle everything else. Examples:
-            // @var CompartmentTypeEnum
-            // @var string
-            // @var array{float,float}
-            else {
+                $schema['properties'][$propertyName] = $this->handleGenericTypeNode($var->type);
+            } elseif ($var->type instanceof UnionTypeNode) {
+                $schema['properties'][$propertyName] = $this->handleUnionTypeNode($var->type);
+            } else {
                 $schema['properties'][$propertyName] = $this->handleType($var->type);
             }
+        }
+
+        // Done!
+        return $schema;
+    }
+
+    /**
+     * handleGenericTypeNode
+     * Split up a type using generics and handle it.
+     *
+     * Limitation 1: We only handle array generics at the moment, ie array<T>.
+     *
+     * Limitation 2: The GenericTypeNode has two members, type and genericTypes,
+     * which allows it to support multiple generics like SomethingClever<T1, T2>
+     * Currently we only support a single generic.
+     *
+     * EG1: An array with an array shape generic, used for coordinates:
+     * array<array{float,float}>
+     *
+     * EG2: A list of children from our schema:
+     * [Array<Subcompartment>
+     *
+     * EG3: A list of a built-in type:
+     * Array<string>
+     *
+     * @param GenericTypeNode $type
+     * @return array<mixed>
+     * @throws \Exception
+     */
+    private function handleGenericTypeNode(GenericTypeNode $type)
+    {
+        $schema = [];
+        $typeName = $type->type->name;
+        // Limitation 1: Only support array types with generics
+        if ($typeName === 'array') {
+            // Limitation2: Only support a single generic.
+            $generic = $type->genericTypes[0];
+
+            // EG1: Array shape generics
+            if ($generic instanceof ArrayShapeNode) {
+                $schema = $this->handleType($generic);
+            } elseif ($generic instanceof IdentifierTypeNode) {
+                // EG2: A list of children fro our schema
+                if (class_exists($this->namespace . $generic->name)) {
+                    $schema = [
+                        'type' => 'array',
+                        'items' => $this->generate($generic->name),
+                    ];
+                }
+
+                // EG3: A list of built-ins
+                else {
+                    $schema = [
+                        'type' => 'array',
+                        'items' => $this->handleType($generic),
+                    ];
+                }
+            }
+        }
+        else throw new \Exception('Cannot handle that type yet: ' . $type->type->name);
+        return $schema;
+    }
+
+    /**
+     * handleUnionTypeNode
+     * Split up a compound aka union type and handle each one seperately. For
+     * example:
+     * string|null
+     *
+     * @param UnionTypeNode $type
+     * @return array<mixed>
+     */
+    private function handleUnionTypeNode(UnionTypeNode $type)
+    {
+        $schema = ['anyOf' => []];
+        foreach ($type->types as $type) {
+            $schema['anyOf'][] = $this->handleType($type);
         }
         return $schema;
     }
@@ -214,7 +253,7 @@ class JsonSchema
     }
 
     /**
-     * Cast php types to a JSON schema equivalent
+     * Cast php types to a JSON schema equivalent.
      * @param string $type
      * @return string
      */

--- a/tests/api/ListingTest.php
+++ b/tests/api/ListingTest.php
@@ -18,7 +18,6 @@ use CloudForest\ApiClientPhp\Scripts\JsonSchema;
 use Opis\JsonSchema\Validator;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 
-
 final class ListingTest extends TestBase
 {
     public function testCreate(): void

--- a/tests/api/ListingTest.php
+++ b/tests/api/ListingTest.php
@@ -31,11 +31,11 @@ final class ListingTest extends TestBase
 
         // Create an inventory structure:
         // Inventory 1, create a boundary Geojson
-        $boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::POLYGON);
+        $boundary = new GeojsonSchema(GeojsonGeometryTypeEnum::Polygon);
         $boundary->geometry->coordinates = [[-1, 53.2], [-1.1, 53.3]];
 
         // Inventory 2, create a centroid Geojson
-        $centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::POINT);
+        $centroid = new GeojsonSchema(GeojsonGeometryTypeEnum::Point);
         $centroid->geometry->coordinates = [-1.05, 53.25];
 
         // Inventory 3, create a compartment


### PR DESCRIPTION
- Move Parser into constructor for reuse
- Refactor JsonSchema a little bit to improve readability
- Remove bail outs to string - these were masking bugs where simple types were being missed. EG `@var float` would have lead to `['type' => 'string']`. Now it explicitly throws if it cannot yet support something
- More casting of php types
- Detailed read of schema, corrected any errors
- tested  schema, corrected any errors
- added phpunit tests for generation and validation

Passing test with latest schema plus a listing generated via cloudforest-conn-demo is: https://www.jsonschemavalidator.net/s/TndEReJT